### PR TITLE
Add tests for Day 2

### DIFF
--- a/src/main/scala/advent/solutions/Day2.scala
+++ b/src/main/scala/advent/solutions/Day2.scala
@@ -1,0 +1,42 @@
+package advent.solutions
+
+/** Day 2: 1202 Program Alarm
+  *
+  * @see https://adventofcode.com/2019/day/2
+  */
+object Day2 {
+
+  object Part1 {
+
+    /** Runs an Intcode program
+      *
+      * @param program A list of opcodes and positions
+      * @return The program after having been run on itself
+      */
+    def run(program: List[Int]): List[Int] = ???
+  }
+
+  object Part2 {
+
+    /** Represents the two numbers provided at addresses 1 and 2 of an Intcode program */
+    final case class Input(noun: Int, verb: Int)
+
+    /** Calculates the input required to produce a given output
+      *
+      * @param program A list of opcodes and positions.  The positions at address 1 and 2 will be replaced with input
+      * @param output  The given output of the program
+      *
+      * @return The input that would be entered in the program to produce the given output
+      */
+    def inputForOutput(program: List[Int], output: Int): Input = ???
+  }
+
+  def main(args: Array[String]): Unit = {
+
+    // Copy the puzzle input from https://adventofcode.com/2019/day/2/input
+    val puzzleInput: List[Int] = ???
+
+    // Solve your puzzle using the functions in parts 1 and 2
+    ???
+  }
+}

--- a/src/test/scala/advent/Day2Spec.scala
+++ b/src/test/scala/advent/Day2Spec.scala
@@ -1,0 +1,27 @@
+package advent
+
+import org.scalatest._
+import advent.solutions._
+
+final class Day2Spec extends FlatSpec with Matchers {
+
+  "Part 1" should "run 1,0,0,0,99 to produce 2,0,0,0,99 (1 + 1 = 2)" in {
+    Day2.Part1.run(List(1, 0, 0, 0, 99)) should be(List(2, 0, 0, 0, 99))
+  }
+
+  it should "run 2,3,0,3,99 to produce 2,3,0,6,99 (3 * 2 = 6)" in {
+    Day2.Part1.run(List(2, 3, 0, 3, 99)) should be(List(2, 3, 0, 6, 99))
+  }
+
+  it should "run 2,4,4,5,99,0 to produce 2,4,4,5,99,9801 (99 * 99 = 9801)" in {
+    Day2.Part1.run(List(2, 4, 4, 5, 99, 0)) should be(
+      List(2, 4, 4, 5, 99, 9801)
+    )
+  }
+
+  it should "run 1,1,1,4,99,5,6,0,99 to produce 30,1,1,4,2,5,6,0,99" in {
+    Day2.Part1.run(List(1, 1, 1, 4, 99, 5, 6, 0, 99)) should be(
+      List(30, 1, 1, 4, 2, 5, 6, 0, 99)
+    )
+  }
+}


### PR DESCRIPTION
This PR adds tests for Day 2.  In addition to the examples, it adds a `main` method for running the solution on a given puzzle input